### PR TITLE
Updates for rug-0.12.0

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -5,10 +5,5 @@
       <username>${env.ATOMIST_REPO_USER}</username>
       <password>${env.ATOMIST_REPO_TOKEN}</password>
     </server>
-    <server>
-      <id>public-atomist-dev</id>
-      <username>${env.ATOMIST_REPO_USER}</username>
-      <password>${env.ATOMIST_REPO_TOKEN}</password>
-    </server>
   </servers>
 </settings>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,51 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/atomist-rugs/travis-rug-type/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/atomist-rugs/travis-rug-type/compare/0.9.0...HEAD
+
+## [0.9.0] - 2017-02-14
+
+[0.9.0]: https://github.com/atomist-rugs/travis-rug-type/compare/0.8.0...0.9.0
+
+Valentine release
+
+### Changed
+
+-   Updates for rug 0.12.0
+
+## [0.8.0] - 2017-02-02
+
+[0.8.0]: https://github.com/atomist-rugs/travis-rug-type/compare/0.7.0...0.8.0
+
+New rug release
+
+### Changed
+
+-   Update to rug 0.11.0
+
+## [0.7.0] - 2017-01-18
+
+[0.7.0]: https://github.com/atomist-rugs/travis-rug-type/compare/0.6.0...0.7.0
+
+New rug release
+
+### Changed
+
+-   Update to rug 0.10.0
+
+## [0.6.0] - 2017-01-12
+
+[0.6.0]: https://github.com/atomist-rugs/travis-rug-type/compare/0.5.0...0.6.0
+
+Restart release
+
+### Added
+
+-   Restart build command
+
+### Changed
+
+-   Update to rug 0.9.0
 
 ## [0.5.0] - 2017-01-05
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.atomist</groupId>
     <artifactId>travis-rug-type</artifactId>
-    <version>0.8.0-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>scala-rug-type</name>
     <description>Rug extension type for Travis</description>
@@ -14,7 +14,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
-		<rug.version>0.11.0</rug.version>
+        <rug.version>0.12.0</rug.version>
     </properties>
     <dependencies>
       <dependency>
@@ -260,29 +260,13 @@
             </snapshots>
             <id>atomist-release</id>
             <name>Atomist Release</name>
-            <url>https://sforzando.artifactoryonline.com/sforzando/libs-release</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>public-atomist-release</id>
-            <name>Atomist Release</name>
             <url>https://atomist.jfrog.io/atomist/libs-release</url>
-        </repository>
-        <repository>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <id>atomist-snapshots</id>
-            <name>Atomist Snapshots</name>
-            <url>https://sforzando.artifactoryonline.com/sforzando/libs-snapshot</url>
         </repository>
     </repositories>
     <distributionManagement>
         <repository>
             <id>public-atomist-release</id>
-            <name>Atomist Release</name>
+            <name>Atomist Release Local</name>
             <url>https://atomist.jfrog.io/atomist/libs-release-local</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
Make changes required for rug-0.12.0.  Change log catch up.

Remove unneeded maven repositories.